### PR TITLE
Add Moisture to TTN.js

### DIFF
--- a/AgroSense_Soil Moisture_Sensor_LoRaWAN/TTN.js
+++ b/AgroSense_Soil Moisture_Sensor_LoRaWAN/TTN.js
@@ -1,14 +1,30 @@
 function decodeUplink(input) {
+    
+    // Optionally define max and min values for ADC
+    // Un-comment the variable value and change to suit your needs
+    var adcMax; //= 1500; // adcMax is "dry" soil
+    var adcMin; //= 1200; // adcMin is "wet" soil
 
+    // User defined number of decimal places as a variable
+    var decimalPlaces = 2;
+
+    // Variables calculated from device payload
     // var num = input.bytes[0] * 256 + input.bytes[1]
-    var bat = input.bytes[4] / 10.0
-    var adc = input.bytes[2] * 256 + input.bytes[3]
-
-    return {
-        data: {
-            field1: bat,
-            field2: adc,
-        },
-
+    var Battery = (input.bytes[4] / 10.0).toFixed(decimalPlaces) + "V";
+    var ADC = input.bytes[2] * 256 + input.bytes[3];
+    
+    // Prepare the data object
+    var data = {
+        Battery: Battery,
+        ADC: ADC
     };
+
+    // Only calculate and add Moisture if adcMax and adcMin are defined
+    if (adcMax !== undefined && adcMin !== undefined) {
+        var Moisture = ((Math.max(0, Math.min(100, ((adcMax - ADC) / (adcMax - adcMin)) * 100)))
+                        .toFixed(decimalPlaces) + "%");
+        data.Moisture = Moisture;
+    }
+
+    return { data: data };
 }

--- a/AgroSense_Soil Moisture_Sensor_LoRaWAN/TTN.js
+++ b/AgroSense_Soil Moisture_Sensor_LoRaWAN/TTN.js
@@ -10,7 +10,7 @@ function decodeUplink(input) {
 
     // Variables calculated from device payload
     // var num = input.bytes[0] * 256 + input.bytes[1]
-    var Battery = (input.bytes[4] / 10.0).toFixed(decimalPlaces) + "V";
+    var Battery = (input.bytes[4] / 10.0).toFixed(decimalPlaces);
     var ADC = input.bytes[2] * 256 + input.bytes[3];
     
     // Prepare the data object
@@ -22,7 +22,7 @@ function decodeUplink(input) {
     // Only calculate and add Moisture if adcMax and adcMin are defined
     if (adcMax !== undefined && adcMin !== undefined) {
         var Moisture = ((Math.max(0, Math.min(100, ((adcMax - ADC) / (adcMax - adcMin)) * 100)))
-                        .toFixed(decimalPlaces) + "%");
+                        .toFixed(decimalPlaces));
         data.Moisture = Moisture;
     }
 


### PR DESCRIPTION
This commit adds an *optional* `Moisture` data value that calculates soil moisture percentage from user-defined `adcMax` and `adcMin` variables. The default behavior is opt-in. *If un-configured,* users will receive Makerfabs default data values of *only* the battery and ADC.

Also adds `decimalPlaces` as a variable to limit data value output to two (2) decimal places by default, this variable is also configurable to suit the user's needs.

Also changes data object keys to be more descriptive. There wasn't anything wrong with them as-is but this saves time when using the Home Assistant TTN integration.